### PR TITLE
Deprecated: strlen() on transaction.php issue resolved

### DIFF
--- a/easebuzz-lib/transaction.php
+++ b/easebuzz-lib/transaction.php
@@ -103,12 +103,11 @@
         $temp = explode('.', $temp);
         //echo $temp;
         $diff_amount_string = '';
-        if(strlen($temp[1]) == 0){
+        if(strlen($temp[1] ?? '') == 0){
             $diff_amount_string = $temp[0].'.0';
             $postedArray['amount'] =$diff_amount_string;
             
-        }
-         elseif( strlen($temp[1])==1 || strlen($temp[1])==2 ){
+        } elseif( strlen($temp[1] ?? '')==1 || strlen($temp[1] ?? '')==2 ){
             $diff_amount_string = $temp[0].'.'.$temp[1];
             
         } else{


### PR DESCRIPTION
If `$postedArray` got an round figure value like
```php
$postedArray['amount'] = '2023';
```

Error on `transaction.php` file on `line 106`
```
Warning: Undefined array key 1 in .\easebuzz-lib\transaction.php on line 106
```
```
Deprecated: strlen(): Passing null to parameter #1 ($string) of type string is deprecated in .\easebuzz-lib\transaction.php on line 106
```

This issue raised on `PHP 8.2`
As of `PHP 8.1` has deprecated passing null as parameters to a lot of core functions like `trim()`, `strlen()`, `htmlspecialchars()`,...etc.

solved the issue with the null coalescing operator `($temp[1] ?? '')` to provide a default value as appropriate.

**Tested on**
PHP **v7.4.33**
PHP **v8.0.26**
PHP **v8.1.13**
PHP **v8.2.0**